### PR TITLE
offset is 0-based, so offset=50 returns 51+

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ http://googlegeodevelopers.blogspot.ca/2009/10/maps-api-v3-now-speaks-your-langu
 ## Record limits
 
 * If no limit is specified, return results with a default limit.
-* To get records 50 through 75 do this:
+* To get records 51 through 75 do this:
     * http://example.gov/magazines?limit=25&offset=50
-    * offset=50 means, ‘begin with record number fifty’
+    * offset=50 means, ‘skip the first 50 records’
     * limit=25 means, ‘return 25 records’
 
 Information about record limits should also be included in the Example resonse. Example:


### PR DESCRIPTION
I submitted the same fix [upstream](https://github.com/WhiteHouse/api-standards/pull/33)
