### PR TITLE
better offsets into frequently changing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,21 +198,22 @@ Information about record limits should also be included in the Example resonse. 
 
 * A `following` parameter may be provided for more reliable collection of
   results for result sets that change frequently
-* `following` replaces the offset parameter with a value from the field
+* `following` replaces the offset parameter with the value from the field
   that has been used to sort the results from the last record returned
+  in the previous call to the API
 
 Example: Using an API that returns entries from an activity log
 in descending time order, and the last record returned had a time stamp
 of `"2013-10-30T15:06:22,556645642Z"` we could ask for the next 50 records
 with:
 
-`GET http://example.com/activities?limit=25&following=2013-10-30T15:06:22,556645642Z`
+`GET http://example.com/activities?limit=50&following=2013-10-30T15:06:22,556645642Z`
 
 Example: Using an API that returns registered users sorted by their
 user names in ascending order, and the last user returned was named
-`"Vicente Cerda"` we could ask for the next group of names with:
+`"Jane Smith"` we could ask for the next group of names with:
 
-`GET http://example.com/users?following=Vicente%20Cerda`
+`GET http://example.com/users?following=Jane%20Smith`
 
 ## Request & Response Examples
 


### PR DESCRIPTION
This solves a real problem we had with our site. We needed to collect all the activities since a given date, but we had to page through them with an API

Since the list of activites is continually being added to, an offset parameter isn't very good: we would get the same activities returned multiple times, making several wasted API calls. There was also the possibility of missing activities completely when an earlier activity gets removed from the list by an administrator.

Using a "following" parameter based on the sort order of the items returned solved these problems nicely, and was very easy to use. It's probably also gentler on the database at the back end too.
